### PR TITLE
Upgrade doctrine/coding-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": "^8.1",
-        "doctrine/coding-standard": "^11.1",
+        "doctrine/coding-standard": "^13",
         "squizlabs/php_codesniffer": "^3.7"
     },
     "config": {


### PR DESCRIPTION
This is to fix the deprecated sniff when running phpcs. I have tested the upgraded version locally and there are minimal changes required in the main repo. 