### PR TITLE
Upgrade doctrine/coding-standard to version 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,35 +4,39 @@ on:
   push:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - master
+
+permissions:
+  contents: read
 
 jobs:
-    test-ruleset:
-        name: Test rules on PHP ${{ matrix.php-version }}
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                php-version: ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
-        steps:
-            - uses: actions/checkout@v3
-            - name: Install xmllint
-              run: |
-                sudo apt update
-                sudo apt install --no-install-recommends -y libxml2-utils
-                sudo apt clean
-            - name: Use php ${{ matrix.php-version }}
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php-version }}
-            - name: Cache module
-              uses: actions/cache@v3
-              with:
-                  path: ~/.composer/cache/
-                  key: composer-cache
-            - name: Install dependencies
-              run: composer install
-            - name: Lint the ruleset
-              run: xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd PhpMyAdmin/ruleset.xml
-            - name: Run php tests
-              run: ./vendor/bin/phpcs --standard=PhpMyAdmin -vv | grep -oF "Processing ruleset $(pwd)/PhpMyAdmin/ruleset.xml"
+  test-ruleset:
+    name: Test rules on PHP ${{ matrix.php-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install xmllint
+        run: |
+          sudo apt update
+          sudo apt install --no-install-recommends -y libxml2-utils
+          sudo apt clean
+
+      - name: Set up PHP ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v4
+
+      - name: Lint the ruleset
+        run: xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd PhpMyAdmin/ruleset.xml
+
+      - name: Run PHP tests
+        run: ./vendor/bin/phpcs --standard=PhpMyAdmin -vv | grep -oF "Processing ruleset $(pwd)/PhpMyAdmin/ruleset.xml"

--- a/PhpMyAdmin/ruleset.xml
+++ b/PhpMyAdmin/ruleset.xml
@@ -7,9 +7,6 @@
         <!-- Do not require multiple assignment alignment -->
         <exclude name="Generic.Formatting.MultipleStatementAlignment"/>
 
-        <!-- Allow the 'global' keyword -->
-        <exclude name="Squiz.PHP.GlobalKeyword"/>
-
         <!-- Disable the superfluous class naming rules -->
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
@@ -18,6 +15,24 @@
 
         <!-- Do not replace /* @var type $foo */ and similar simple inline annotations with assert() -->
         <exclude name="SlevomatCodingStandard.PHP.RequireExplicitAssertion"/>
+
+        <!-- Checked by Generic.WhiteSpace.LanguageConstructSpacing -->
+        <exclude name="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+    </rule>
+
+    <rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
+
+    <!-- Enforces conditions to be on a single line when it fit on the line. -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireSingleLineCondition"/>
+
+    <!-- Enforces function call to be on a single line when it fits on the line. -->
+    <rule ref="SlevomatCodingStandard.Functions.RequireSingleLineCall"/>
+
+    <!-- Checks duplicate spaces. -->
+    <rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces">
+        <properties>
+            <property name="ignoreSpacesInComment" value="true"/>
+        </properties>
     </rule>
 
     <!-- Disable modern class name reference on objects (PHP 8.0+) -->
@@ -27,17 +42,82 @@
         </properties>
     </rule>
 
-    <!-- Do not require usage of null coalesce operator equal operator (PHP 7.4+) -->
+    <!-- Disable usage of constructor property promotion (PHP 8.0+) -->
+    <rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion">
+        <properties>
+            <property name="enable" value="false"/>
+        </properties>
+    </rule>
+
+    <!-- Disable usage of null coalesce operator equal operator (PHP 7.4+) -->
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator">
         <properties>
             <property name="enable" value="false"/>
         </properties>
     </rule>
 
-    <!-- Disable native type hints for properties (PHP 7.4+) -->
+    <!-- Disable usage of null safe operator when possible (PHP 8.0+) -->
+    <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullSafeObjectOperator">
+        <properties>
+            <property name="enable" value="false"/>
+        </properties>
+    </rule>
+
+    <!-- Disable non-capturing catch when the variable with exception is not used (PHP 8.0+) -->
+    <rule ref="SlevomatCodingStandard.Exceptions.RequireNonCapturingCatch">
+        <properties>
+            <property name="enable" value="false"/>
+        </properties>
+    </rule>
+
+    <!-- Disable trailing commas in multiline function calls (PHP 7.3+) -->
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall">
+        <properties>
+            <property name="enable" value="false"/>
+        </properties>
+    </rule>
+
+    <!-- Disable trailing commas in multiline function declarations (PHP 8.0+) -->
+    <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration">
+        <properties>
+            <property name="enable" value="false"/>
+        </properties>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+        <properties>
+            <property name="enableMixedTypeHint" value="false"/><!-- PHP 8.0+ -->
+            <property name="enableUnionTypeHint" value="false"/><!-- PHP 8.0+ -->
+            <property name="enableIntersectionTypeHint" value="false"/><!-- PHP 8.1+ -->
+            <property name="enableStandaloneNullTrueFalseTypeHints" value="false"/><!-- PHP 8.2+ -->
+        </properties>
+    </rule>
+
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
         <properties>
-            <property name="enableNativeTypeHint" value="false"/>
+            <property name="enableNativeTypeHint" value="false"/><!-- PHP 7.4+ -->
+            <property name="enableMixedTypeHint" value="false"/><!-- PHP 8.0+ -->
+            <property name="enableUnionTypeHint" value="false"/><!-- PHP 8.0+ -->
+            <property name="enableIntersectionTypeHint" value="false"/><!-- PHP 8.1+ -->
+            <property name="enableStandaloneNullTrueFalseTypeHints" value="false"/><!-- PHP 8.2+ -->
+        </properties>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+        <properties>
+            <property name="enableStaticTypeHint" value="false"/><!-- PHP 8.0+ -->
+            <property name="enableMixedTypeHint" value="false"/><!-- PHP 8.0+ -->
+            <property name="enableUnionTypeHint" value="false"/><!-- PHP 8.0+ -->
+            <property name="enableIntersectionTypeHint" value="false"/><!-- PHP 8.1+ -->
+            <property name="enableNeverTypeHint" value="false"/><!-- PHP 8.1+ -->
+            <property name="enableStandaloneNullTrueFalseTypeHints" value="false"/><!-- PHP 8.2+ -->
+        </properties>
+    </rule>
+
+    <!-- Disable union type hint (PHP 8.0+) -->
+    <rule ref="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat">
+        <properties>
+            <property name="enable" value="false"/>
         </properties>
     </rule>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         "issues": "https://github.com/phpmyadmin/coding-standard/issues"
     },
     "require": {
-        "php": "^7.1 || ^8.0",
-        "doctrine/coding-standard": "^9.0.0",
-        "squizlabs/php_codesniffer": "^3.6.0"
+        "php": "^7.2 || ^8.0",
+        "doctrine/coding-standard": "^12.0",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "config": {
         "sort-packages": true,


### PR DESCRIPTION
- Fix `Squiz.WhiteSpace.LanguageConstructSpacing` deprecation
- Drops support for PHP 7.1
- Adds support for PHP 8.5