### PR TITLE
Replace apt with apt-get to fix warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,9 @@ jobs:
 
       - name: Install xmllint
         run: |
-          sudo apt update
-          sudo apt install --no-install-recommends -y libxml2-utils
-          sudo apt clean
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y libxml2-utils
+          sudo apt-get clean
 
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
https://github.com/phpmyadmin/coding-standard/actions/runs/30825474240/job/91725866482#step:3:52

```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```